### PR TITLE
Fixed communicator in checkSuccess() to comm instead of MPI_COMM_WORLD.

### DIFF
--- a/vlsv_writer.cpp
+++ b/vlsv_writer.cpp
@@ -50,8 +50,8 @@ namespace vlsv {
       if (myStatus == false) mySuccess = 1;
       
       // Sum mySuccess values to master process and broadcast to all processes:
-      MPI_Reduce(&mySuccess,&globalSuccess,1,MPI_Type<int32_t>(),MPI_SUM,0,MPI_COMM_WORLD);
-      MPI_Bcast(&globalSuccess,1,MPI_Type<int32_t>(),0,MPI_COMM_WORLD);
+      MPI_Reduce(&mySuccess,&globalSuccess,1,MPI_Type<int32_t>(),MPI_SUM,0,comm);
+      MPI_Bcast(&globalSuccess,1,MPI_Type<int32_t>(),0,comm);
       
       // If globalSuccess equals zero all processes called this function with myStatus set to 'true':
       if (globalSuccess == 0) return true;


### PR DESCRIPTION
This is a bugfix for the checkSuccess() function. It is hanging in one use case in vlasiator (https://github.com/fmihpc/vlasiator/issues/98).

It should be pushed across branches (transform needs that too).
