### PR TITLE
Fixed parallel readParameter

### DIFF
--- a/vlsv_reader_parallel.h
+++ b/vlsv_reader_parallel.h
@@ -126,4 +126,3 @@ namespace vlsv {
 
 }
    
-#endif

--- a/vlsv_reader_parallel.h
+++ b/vlsv_reader_parallel.h
@@ -120,9 +120,10 @@ namespace vlsv {
       if (success == true) masterSuccess = 1;
       MPI_Bcast(&value,1,MPI_Type<T>(),masterRank,comm);
       MPI_Bcast(&masterSuccess,1,MPI_Type<uint8_t>(),masterRank,comm);
-      if (masterSuccess > 0) success = true;
+      success = (masterSuccess > 0);
       return success;
    }
-
 }
-   
+#endif
+
+


### PR DESCRIPTION
readParameter had a bug.  If the parameter reading failed, then only the master rank returned false while the others returned true. This patch fixes it.
