### PR TITLE
Fix bug where a pointer was taken to the chars of a temporary string.

### DIFF
--- a/vlsv_writer.cpp
+++ b/vlsv_writer.cpp
@@ -127,7 +127,7 @@ namespace vlsv {
          
          double t_start = MPI_Wtime();
          if (dryRunning == false) {
-            MPI_File_write_at_all(fileptr, endOffset, footerString.c_str(), footerString.size()+1, MPI_BYTE, MPI_STATUSES_IGNORE);
+            MPI_File_write_at_all(fileptr, endOffset, (char*)footerString.c_str(), footerString.size()+1, MPI_BYTE, MPI_STATUSES_IGNORE);
          }
          writeTime += (MPI_Wtime() - t_start);
          bytesWritten += footerStream.str().size()+1;
@@ -396,12 +396,14 @@ namespace vlsv {
             const double t_start = MPI_Wtime();
             MPI_File_write_at_all(fileptr,offset,multiwriteOffsetPointer,1,outputType,MPI_STATUS_IGNORE);
             writeTime += (MPI_Wtime() - t_start);
+            MPI_Barrier(comm);
             MPI_Type_free(&outputType);
          } else {
             // Process has no data to write but needs to participate in the collective call to prevent deadlock:
             const double t_start = MPI_Wtime();
             MPI_File_write_at_all(fileptr,offset,NULL,0,MPI_BYTE,MPI_STATUS_IGNORE);
             writeTime += (MPI_Wtime() - t_start);
+            MPI_Barrier(comm);
          }
       }
 

--- a/vlsv_writer.cpp
+++ b/vlsv_writer.cpp
@@ -127,10 +127,10 @@ namespace vlsv {
          
          double t_start = MPI_Wtime();
          if (dryRunning == false) {
-            MPI_File_write_at_all(fileptr, endOffset, footerString.data(), footerString.size(), MPI_BYTE, MPI_STATUSES_IGNORE);
+            MPI_File_write_at_all(fileptr, endOffset, footerString.c_str(), footerString.size()+1, MPI_BYTE, MPI_STATUSES_IGNORE);
          }
          writeTime += (MPI_Wtime() - t_start);
-         bytesWritten += footerStream.str().size();
+         bytesWritten += footerStream.str().size()+1;
       }
 
       // Close MPI file:


### PR DESCRIPTION
This was done when writing the footer when closing the file.  Accessing this footer data worked sometimes, other times not. See also vlasiator issue #149 (not public).
