### PR TITLE
MUXML End-of-file workaround

### DIFF
--- a/muxml.cpp
+++ b/muxml.cpp
@@ -225,7 +225,10 @@ bool MuXML::read(std::istream& in,XMLNode* parent,const int& level,const char& c
 	 while ((c == ' ' || c == '\t' || c == '\n') && in.good() == true) in >> c;
       }
       
-      if (in.good() == false) return false;
+      if (in.good() == false && in.eof() == false) return false;
+      if (in.eof() == true) {
+         return true;
+      }
    } while (success == true);
    return true;
 }

--- a/vlsv_common.h
+++ b/vlsv_common.h
@@ -155,7 +155,6 @@ namespace vlsv {
    
    template<typename T> T convertFloat(const char* const ptr);
    template<typename T> T convertInteger(const char* const ptr,const bool& swapEndianness=false);
-   template<typename T> void convertValue(T& value,const char* const ptr,datatype::type dt,int dataSize,const bool& swapEndianness=false);
    
    /** Returns a string representation of a basic datatype that 
     * is to be written to an array in output file.


### PR DESCRIPTION
As discussed in #27, muxml fails to read vlsv files since it chokes on the end of file with newer stdlib version. Not certain why this is the case (has the end-of-file behaviour changed?), but this workaround appears to help for the time being.

An alternative approach for fixing this might be a newer version of muxml.