### PR TITLE
Combined writes

### DIFF
--- a/buffered_test.cpp
+++ b/buffered_test.cpp
@@ -1,0 +1,167 @@
+#include <cstdlib>
+#include <iostream>
+#include <iomanip> 
+#include <cmath>
+#include <sstream>
+#include <ctime>
+#include <array>
+#include <algorithm>
+#include <limits>
+#include <numeric>
+
+#include "vlsv_writer.h"
+#include "vlsv_amr.h"
+
+using namespace vlsv;
+
+// use the buffered API or not
+#define BUFFERED
+
+std::vector<int> sizes = {540,554,540,21,65,56,53,21,64,24};
+std::vector<int> sizes2 = {1,2,10,100,1000,10000};
+std::vector<int> parts = {1,3,2,1,1,1,10,1,1,1};
+std::vector<int> parts2 = {1,2,5,10};
+
+
+int *intData;
+int myrank;
+
+
+void writeNint(vlsv::Writer &vlsv, int N, int writeParts, int vectorSize)
+{
+	std::cout << myrank << " added " << std::endl;
+	std::map<std::string, std::string> xmlAttributes;
+	xmlAttributes["Arr"] = "name";
+
+	vlsv.startMultiwrite(getStringDatatype<int>(),N*writeParts,vectorSize,sizeof(int));
+	for (size_t i = 0; i < writeParts; i++)
+	{
+		vlsv.addMultiwriteUnit((char*)intData,N);
+	}
+	vlsv.endMultiwrite("arrayName"+std::to_string(N),xmlAttributes);
+}
+
+void setBuffers(vlsv::Writer &vlsv, int bufferSize)
+{
+	bool same = false;
+#ifdef BUFFERED
+	if(!same)
+	{
+		if(myrank == 1)	   
+			vlsv.setBuffer(bufferSize);
+		else
+			vlsv.setBuffer(bufferSize/10);
+	}
+	else
+		vlsv.setBuffer(bufferSize);
+#endif
+}
+
+int main(int argc,char* argv[]) {
+   	bool success = true;
+
+	if (argc == 1)
+	{
+		std::cout << "usage : a.out buffer_size"
+		std::cout << "for MPI with up to 10 processes: mpiexec -n 10 a.out buffer_size"
+	}
+
+   // Init MPI:
+   	MPI_Init(&argc,&argv);
+	MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+
+	int bufferSize = std::atoi(argv[1]);
+
+	int totSize = 10000;
+	intData = new int[totSize];
+
+	for (size_t i = 0; i < totSize; i++)
+	{
+		intData[i] = myrank;
+	}
+
+	
+	{
+		// all writing the same size messages
+		vlsv::Writer vlsv;
+		setBuffers(vlsv, bufferSize);
+	   	if (vlsv.open("allTheSame.out"+std::to_string(bufferSize),MPI_COMM_WORLD,0) == false) {
+			  success = false;
+		 	 MPI_Finalize();	
+		 	 return 1;
+		}
+		for(auto size: sizes2)
+		for(auto part: parts)
+			writeNint(vlsv, size, part, 1);
+
+		if (vlsv.close() == false) {
+			success = false;
+	   	}
+	}
+	
+	
+	{
+		// all writing different size messages
+		vlsv::Writer vlsv;
+
+		setBuffers(vlsv, bufferSize);
+	   	if (vlsv.open("allDifferent.out"+std::to_string(bufferSize),MPI_COMM_WORLD,0) == false) {
+			  success = false;
+		 	 MPI_Finalize();	
+		 	 return 1;
+		}
+
+		writeNint(vlsv, sizes[myrank], parts[myrank], 1);
+
+		if (vlsv.close() == false) {
+			success = false;
+	   	}
+	}
+	
+	{
+		// all but one writing
+		vlsv::Writer vlsv;
+
+		setBuffers(vlsv, bufferSize);
+	   	if (vlsv.open("allBut1.out"+std::to_string(bufferSize),MPI_COMM_WORLD,0) == false) {
+			  success = false;
+		 	 MPI_Finalize();	
+		 	 return 1;
+		}
+
+		if(myrank == 4)
+			writeNint(vlsv, 0, 1, 1);	
+		else
+			writeNint(vlsv, sizes[myrank], parts[myrank], 1);
+
+
+		if (vlsv.close() == false) {
+			success = false;
+	   	}
+	}
+	
+	{
+		// only one writing 
+		vlsv::Writer vlsv;
+
+		setBuffers(vlsv, bufferSize);
+	   	if (vlsv.open("only1.out"+std::to_string(bufferSize),MPI_COMM_WORLD,0) == false) {
+			  success = false;
+		 	 MPI_Finalize();	
+		 	 return 1;
+		}
+
+		if(myrank == 5)
+			writeNint(vlsv, sizes[myrank], 1, 1);
+		else
+			writeNint(vlsv, 0, 0, 1);	
+		
+		if (vlsv.close() == false) {
+			success = false;
+	   	}
+	}
+
+	   MPI_Finalize();
+ 	  if (success == false) return 1;
+	return 0;
+}

--- a/vlsv_writer.cpp
+++ b/vlsv_writer.cpp
@@ -737,7 +737,7 @@ namespace vlsv {
          MPI_Aint *disp = new MPI_Aint[fileOffsets.size()];
          MPI_Datatype *typs = new MPI_Datatype[fileOffsets.size()];
 
-         for(int i = 0; i < fileOffsets.size(); i++)
+         for(size_t i = 0; i < fileOffsets.size(); i++)
          {
             len[i] = startSize[i].second;
             // assuming file offsets are given from current view start
@@ -752,7 +752,7 @@ namespace vlsv {
          MPI_File_set_view(fileptr, 0, MPI_BYTE, viewType, "native", MPI_INFO_NULL );
 
          // write out buffer
-         MPI_File_write_at(fileptr, 0, outputBuffer, bufferTop, MPI_BYTE, MPI_STATUS_IGNORE);
+         MPI_File_write_at_all(fileptr, 0, outputBuffer, bufferTop, MPI_BYTE, MPI_STATUS_IGNORE);
         
          // put old view back
          MPI_File_set_view(fileptr, originalOffset, originalEType, originalView, "native", MPI_INFO_NULL );
@@ -787,7 +787,7 @@ namespace vlsv {
       startSize.push_back(std::pair<int,int>(bufferTop, size));
       fileOffsets.push_back(fileOffset);
       // pack the data for the write into the buffer
-      int err = MPI_Pack(data, 1, datatype,outputBuffer,bufferSize,&bufferTop, comm);
+      MPI_Pack(data, 1, datatype,outputBuffer,bufferSize,&bufferTop, comm);
    }
 
 } // namespace vlsv

--- a/vlsv_writer.cpp
+++ b/vlsv_writer.cpp
@@ -531,12 +531,12 @@ namespace vlsv {
          int writeSize = 0;
          MPI_Datatype outputType;
          
-//         if (N_multiwriteUnits > 0) {
+         if (N_multiwriteUnits > 0) {
             // Create an MPI struct containing the multiwrite units:
             MPI_Type_create_struct(N_multiwriteUnits,blockLengths,displacements,types,&outputType);
             MPI_Type_commit(&outputType);
             MPI_Type_size(outputType, &writeSize);
-//         }
+         }
 
          // is the current write to big to ever fit into the buffer?
          int notBuffer = writeSize > bufferSize;
@@ -745,7 +745,6 @@ namespace vlsv {
     // create datatype based on what is in the buffer
     MPI_Type_create_struct(fileOffsets.size(),len,disp,typs,&viewType);
     MPI_Type_commit(&viewType);
-    std::cout << myrank << " emptying buffer" << std::endl;
     
     // write out buffer
     if(bufferTop!=0)
@@ -772,13 +771,11 @@ namespace vlsv {
    void Writer::addToBuffer(char * data, int size,  MPI_Offset fileOffset, MPI_Datatype datatype, MPI_Comm comm)
    {
       
-      std::cout << "adding to buffer " << myrank << std::endl;
       int bufferFull = 0;
       // would the new write fill the buffer
       if(bufferTop + size >= bufferSize)
       {
         bufferFull = 1;
-        std::cout << "buffer full @ " << myrank << std::endl;
       }
       int bufferFullGlobal = 0;
       // see if anyone else has a full buffer
@@ -792,7 +789,9 @@ namespace vlsv {
       startSize.push_back(std::pair<int,int>(bufferTop, size));
       fileOffsets.push_back(fileOffset);
       // pack the data for the write into the buffer
-      MPI_Pack(data, 1, datatype,outputBuffer,bufferSize,&bufferTop, comm);
+      // if there is data to pack
+      if(size > 0)
+        MPI_Pack(data, 1, datatype,outputBuffer,bufferSize,&bufferTop, comm);
    }
 
 } // namespace vlsv

--- a/vlsv_writer.cpp
+++ b/vlsv_writer.cpp
@@ -530,12 +530,12 @@ namespace vlsv {
          int writeSize = 0;
          MPI_Datatype outputType;
          
-         if (N_multiwriteUnits > 0) {
+//         if (N_multiwriteUnits > 0) {
             // Create an MPI struct containing the multiwrite units:
             MPI_Type_create_struct(N_multiwriteUnits,blockLengths,displacements,types,&outputType);
             MPI_Type_commit(&outputType);
             MPI_Type_size(outputType, &writeSize);
-         }
+//         }
 
          // is the current write to big to ever fit into the buffer?
          int notBuffer = writeSize > bufferSize;
@@ -566,7 +566,6 @@ namespace vlsv {
          else{
             // buffer the write
             addToBuffer(multiwriteOffsetPointer, writeSize, offset+unitOffset,outputType,comm);
-            
          }         
       }
 
@@ -718,23 +717,26 @@ namespace vlsv {
 
    void Writer::emptyBuffer(MPI_Comm comm)
    {
-      // parameters for original file view
-      MPI_Datatype originalView;
-      MPI_Datatype originalEType;
-      MPI_Offset originalOffset;
-      char rep[128];
-    
-      // save original view
-      MPI_File_get_view(fileptr, &originalOffset, &originalEType, &originalView, rep);
-      // write out contents of buffer
       if(bufferTop!= 0)
       {
-         std::cout << "emptying buffer" << std::endl;
+
+         // parameters for original file view
+         MPI_Datatype originalView;
+         MPI_Datatype originalEType;
+         MPI_Offset originalOffset;
+         char rep[128];
+    
+         // save original view
+         MPI_File_get_view(fileptr, &originalOffset, &originalEType, &originalView, rep);
+         // write out contents of buffer
+
+
+         std::cout << myrank << " emptying buffer" << std::endl;
          MPI_Datatype viewType;
          int *len = new int[fileOffsets.size()];
          MPI_Aint *disp = new MPI_Aint[fileOffsets.size()];
          MPI_Datatype *typs = new MPI_Datatype[fileOffsets.size()];
-         
+
          for(int i = 0; i < fileOffsets.size(); i++)
          {
             len[i] = startSize[i].second;
@@ -752,13 +754,13 @@ namespace vlsv {
          // write out buffer
          MPI_File_write_at(fileptr, 0, outputBuffer, bufferTop, MPI_BYTE, MPI_STATUS_IGNORE);
         
+         // put old view back
+         MPI_File_set_view(fileptr, originalOffset, originalEType, originalView, "native", MPI_INFO_NULL );
       }
 
       bufferTop = 0;
       startSize.clear();
       fileOffsets.clear();
-      // put old view back
-      MPI_File_set_view(fileptr, originalOffset, originalEType, originalView, "native", MPI_INFO_NULL );
       
    }
 

--- a/vlsv_writer.h
+++ b/vlsv_writer.h
@@ -95,28 +95,8 @@ namespace vlsv {
 			      const uint64_t& arraySize,T* array,MPI_Op operation);
    
 
-      int getBuffer()
-      {
-        return bufferSize;
-      }
-      void setBuffer(uint64_t bSize)
-      {
-
-        if(bufferSize > 0)
-        {
-          delete outputBuffer;
-        }
-        if(bSize >= std::numeric_limits<int >::max())
-        {
-          std::cout << "buffered I/O not supported for larger than 2GB buffers" << std::endl;
-          bufferTop = 0;
-          bufferSize = 0;
-          return;
-        }
-        bufferTop = 0;
-        bufferSize = bSize;
-        outputBuffer = new char[bufferSize];
-      }
+      int getBuffer();
+      void setBuffer(uint64_t bSize);
  
     private:
       void emptyBuffer(MPI_Comm comm);

--- a/vlsv_writer.h
+++ b/vlsv_writer.h
@@ -50,6 +50,8 @@
  * timestep                      Current value of time step, VisIt shows this value as 'Timestep'.
  */
 
+
+
 namespace vlsv {
 
    class Writer {
@@ -92,7 +94,32 @@ namespace vlsv {
       bool writeWithReduction(const std::string& arrayName,const std::map<std::string,std::string>& attribs,
 			      const uint64_t& arraySize,T* array,MPI_Op operation);
    
+
+      int getBuffer()
+      {
+        return bufferSize;
+      }
+      void setBuffer(int bSize)
+      {
+        if(bufferSize > 0)
+        {
+          delete outputBuffer;
+        }
+        bufferTop = 0;
+        bufferSize = bSize;
+        outputBuffer = new char[bufferSize];
+      }
+ 
     private:
+      void emptyBuffer(MPI_Comm comm);
+      void addToBuffer(char * data, int size, MPI_Offset fileOffset, MPI_Datatype datatype, MPI_Comm comm);
+
+      char* outputBuffer;
+      int bufferSize;
+      int bufferTop;
+
+      std::vector<std::pair<int, int>> startSize;
+      std::vector<MPI_Offset> fileOffsets;
 
       uint64_t arraySize;                     /**< Number of array elements this process will write.*/
       int* blockLengths;                      /**< Used in creation of an MPI_Struct in endMultiwrite.*/

--- a/vlsv_writer.h
+++ b/vlsv_writer.h
@@ -101,9 +101,17 @@ namespace vlsv {
       }
       void setBuffer(uint64_t bSize)
       {
+
         if(bufferSize > 0)
         {
           delete outputBuffer;
+        }
+        if(bSize >= std::numeric_limits<int >::max())
+        {
+          std::cout << "buffered I/O not supported for larger than 2GB buffers" << std::endl;
+          bufferTop = 0;
+          bufferSize = 0;
+          return;
         }
         bufferTop = 0;
         bufferSize = bSize;

--- a/vlsv_writer.h
+++ b/vlsv_writer.h
@@ -99,7 +99,7 @@ namespace vlsv {
       {
         return bufferSize;
       }
-      void setBuffer(int bSize)
+      void setBuffer(uint64_t bSize)
       {
         if(bufferSize > 0)
         {


### PR DESCRIPTION
Added the ability to buffer smaller writes and write them all as a large combined write later.
Should solve some I/O issues on Marconi, someone who has run the code there can fill in the performance details.
Included test in buffered_test.cpp to show the modified version produces the same binary result as the original version