### PR TITLE
Fix for issue #31

### DIFF
--- a/vlsv_common_mpi.cpp
+++ b/vlsv_common_mpi.cpp
@@ -104,9 +104,6 @@ namespace vlsv {
    MPI_Datatype getMPIDatatype(datatype::type dt,uint64_t dataSize) {
       switch (dt) {
        case datatype::UNKNOWN:
-         // TEST
-         cerr << "(VLSV) ERROR: VLSV::getMPIDatatype called with datatype::UNKNOWN datatype, returning MPI_DATATYPE_NULL!" << endl;
-         // END TEST
          return MPI_DATATYPE_NULL;
          break;
        case datatype::INT:

--- a/vlsv_reader_parallel.cpp
+++ b/vlsv_reader_parallel.cpp
@@ -54,8 +54,7 @@ namespace vlsv {
       if (arrayElements == 0) return true;
       
       // Get the byte size of the MPI primitive datatype (MPI_INT etc.) used here:
-      int datatypeBytesize;
-      MPI_Type_size(getMPIDatatype(arrayOpen.dataType,arrayOpen.dataSize),&datatypeBytesize);
+      int datatypeBytesize = arrayOpen.dataSize;
 
       // Calculate the maximum number of array elements written using a single multi-write.
       // Note: element = vector of size vectorSize, each vector element has byte size of datatypeBytesize.
@@ -80,10 +79,15 @@ namespace vlsv {
                               elements*arrayOpen.vectorSize));
          }
       } else {
-         multiReadUnits.push_back(
-             Multi_IO_Unit(buffer,
-                           getMPIDatatype(arrayOpen.dataType,arrayOpen.dataSize),
-                           arrayElements*arrayOpen.vectorSize));
+	 if ( getMPIDatatype(arrayOpen.dataType,arrayOpen.dataSize) == MPI_DATATYPE_NULL ) {
+	    multiReadUnits.push_back(Multi_IO_Unit(buffer,
+						   MPI_Type<uint8_t>(),
+						   arrayElements*arrayOpen.vectorSize*arrayOpen.dataSize));
+	 } else {
+	    multiReadUnits.push_back(Multi_IO_Unit(buffer,
+						   getMPIDatatype(arrayOpen.dataType,arrayOpen.dataSize),
+						   arrayElements*arrayOpen.vectorSize));
+	 }
       }
       
       return success;


### PR DESCRIPTION
Corsair restarts were failing because multi IO units were returning
incorrect byte size for particle arrays.