### PR TITLE
Skip MPI_Get_count when readSize is 0 to avoid an error printing.

### DIFF
--- a/vlsv_reader_parallel.cpp
+++ b/vlsv_reader_parallel.cpp
@@ -511,14 +511,16 @@ namespace vlsv {
          }
 
          // Check that we got everything we requested:
-         int bytesReceived;
-         MPI_Get_count(&status,MPI_BYTE,&bytesReceived);
-         if (bytesReceived != readSize) {
-            stringstream ss;
-            ss << "ERROR in vlsv::ParallelReader! I only got " << bytesReceived << "/" << readSize;
-            ss << " bytes in " << __FILE__ << ":" << __LINE__ << endl;
-            cerr << ss.str();
-            success = false;
+         if(readSize>0) {
+            int bytesReceived;
+            MPI_Get_count(&status,MPI_BYTE,&bytesReceived);
+            if (bytesReceived != readSize) {
+               stringstream ss;
+               ss << "ERROR in vlsv::ParallelReader! I only got " << bytesReceived << "/" << readSize;
+               ss << " bytes in " << __FILE__ << ":" << __LINE__ << endl;
+               cerr << ss.str();
+               success = false;
+            }
          }
 
          offset += readSize;


### PR DESCRIPTION
We're getting
>ERROR in vlsv::ParallelReader! I only got -32766/0 bytes in vlsv_reader_parallel.cpp:519
because MPI_Get_count returns MPI_UNDEFINED (-32766) if the amount of data in status is not an exact multiple of the size of datatype. This breaks I guess as we have a non-zero datatype but a readSize of 0.

I haven't tested (yet), I could test if get again access on Marconi. I am pretty sure this should not introduce any extra bugs however.