### PR TITLE
Skip emptyBuffer if buffersize is 0.

### DIFF
--- a/vlsv_writer.cpp
+++ b/vlsv_writer.cpp
@@ -718,6 +718,11 @@ namespace vlsv {
   void Writer::emptyBuffer(MPI_Comm comm)
   {
 
+   // No need to do anything if we don't have a buffer.
+   if(bufferSize == 0) {
+      return;
+   }
+
    // parameters for original file view
    MPI_Datatype originalView;
    MPI_Datatype originalEType;


### PR DESCRIPTION
This caused the cray mpich-romio implementation to crash with a suprious out of
memory error message, when trying to allocate a zero-sized temporary buffer.