### PR TITLE
Fixing bug in multiwrite with multiple MPI writes

### DIFF
--- a/vlsv_writer.cpp
+++ b/vlsv_writer.cpp
@@ -473,7 +473,9 @@ namespace vlsv {
       for (size_t i=0; i<multiwriteList.size(); ++i) {
          if (multiwriteFlush(i,unitOffset,multiwriteList[i].first,multiwriteList[i].second) == false) success = false;
          for (std::list<Multi_IO_Unit>::iterator it=multiwriteList[i].first; it!=multiwriteList[i].second; ++it) {
-            unitOffset += it->amount*dataSize;
+	    int datatypeBytesize;
+            MPI_Type_size(it->mpiType,&datatypeBytesize);
+            unitOffset += it->amount*datatypeBytesize;
          }
       }
 


### PR DESCRIPTION
This fixes a bug in my use case where particles were not being output correctly for RHybrid+corsair in restart files. Previously simulations would either quietly write out particles in nonsense locations leaving large empty gaps in the correct file offset or die with a segfault, depending on the MPI implementation (OpenMpi, intel mpi). This was triggered anytime a processor had more than the number of particles that would correspond to the systems MaxBytesPerWrite. 