### PR TITLE
Multidimensional parameters, default=1.

### DIFF
--- a/vlsv_writer.h
+++ b/vlsv_writer.h
@@ -88,7 +88,7 @@ namespace vlsv {
 		      const uint64_t& arraySize,const uint64_t& vectorSize,const T* array);
       
       template<typename T>
-      bool writeParameter(const std::string& parameterName,const T* const array);
+      bool writeParameter(const std::string& parameterName,const T* const array, uint64_t vectorSize=1);
       
       template<typename T>
       bool writeWithReduction(const std::string& arrayName,const std::map<std::string,std::string>& attribs,
@@ -206,12 +206,12 @@ namespace vlsv {
     * @param array Pointer to array containing the parameter value. Only significant at master process.
     * @return If true, parameter was written successfully.*/
    template<typename T> inline
-   bool Writer::writeParameter(const std::string& parameterName,const T* const array) {
+   bool Writer::writeParameter(const std::string& parameterName,const T* const array,uint64_t vectorSize) {
       std::map<std::string,std::string> attributes;
       attributes["name"] = parameterName;
    
       if (myrank == masterRank)
-        return writeArray("PARAMETER",attributes,1,1,array);
+        return writeArray("PARAMETER",attributes,1,vectorSize,array);
       else
         return writeArray("PARAMETER",attributes,0,0,array);
    }


### PR DESCRIPTION
If e.g. a vector of floats is passed as `&vector[0]` this goes smoothly and a PARAMETER of more than 1 scalar is written successfully using Vlasiator.

With the default value of 1 this does not break anything at least in Vlasiator.

Open for discussion here or on Flowdock, in particular I'd like @sandroos' comments.