### PR TITLE
Have the visit plugin add variables of unknown vector length as arrays.

### DIFF
--- a/visit-plugin/avtVlsvFileFormat.C
+++ b/visit-plugin/avtVlsvFileFormat.C
@@ -397,6 +397,7 @@ void avtVlsvFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData* md) {
 	    AddTensorVarToMetaData(md,(*var).name,it->second->getName(),centering,9);
 	    break;
 	  default:
+	    AddArrayVarToMetaData(md,(*var).name,(*var).vectorSize,it->second->getName(),centering);
 	    break;
 	 }
       }


### PR DESCRIPTION
Before, everything that was not 1,2,3 or 9 components was silently discarded, now these can be accessed through custom expressions in VisIt.