### PR TITLE
1) Update to VTK API 7.1+, changed VTK_API flag to version number ins…

### DIFF
--- a/visit-plugin/mesh_reader_visit_quad_multi.cpp
+++ b/visit-plugin/mesh_reader_visit_quad_multi.cpp
@@ -31,6 +31,7 @@
 #include <vtkUnsignedCharArray.h>
 #include <vtkPoints.h>
 #include <vtkUnstructuredGrid.h>
+#include <vtkInformation.h>
 #include <vtkFloatArray.h>
 #include <vtkStreamingDemandDrivenPipeline.h>
 
@@ -208,7 +209,9 @@ namespace vlsvplugin {
       
       // Copy ghost cell information to vtkUnstructuredGrid:
       ugrid->GetCellData()->AddArray(ghostZones);
-      #ifdef NEW_VTK_API
+      #if VTK_API >= 71
+         ugrid->GetInformation()->Set(vtkStreamingDemandDrivenPipeline::UPDATE_NUMBER_OF_GHOST_LEVELS(), 0);
+      #elif VTK_API >= 50
          vtkStreamingDemandDrivenPipeline::SetUpdateGhostLevel(ugrid->GetInformation(), 0);
       #else
          ugrid->SetUpdateGhostLevel(0);

--- a/visit-plugin/mesh_reader_visit_ucd_amr.cpp
+++ b/visit-plugin/mesh_reader_visit_ucd_amr.cpp
@@ -30,6 +30,7 @@
 #include <vtkPoints.h>
 #include <vtkFloatArray.h>
 #include <vtkDoubleArray.h>
+#include <vtkInformation.h>
 #include <vtkStreamingDemandDrivenPipeline.h>
 
 #include <vlsv_amr.h>
@@ -691,10 +692,12 @@ namespace vlsvplugin {
 
       // Copy ghost cell information to vtkUnstructuredGrid:
       ugrid->GetCellData()->AddArray(ghostZones);
-      #ifdef NEW_VTK_API
-      vtkStreamingDemandDrivenPipeline::SetUpdateGhostLevel(ugrid->GetInformation(), 0);
+      #if VTK_API >= 71
+         ugrid->GetInformation()->Set(vtkStreamingDemandDrivenPipeline::UPDATE_NUMBER_OF_GHOST_LEVELS(), 0);
+      #elif VTK_API >= 50
+         vtkStreamingDemandDrivenPipeline::SetUpdateGhostLevel(ugrid->GetInformation(), 0);
       #else
-      ugrid->SetUpdateGhostLevel(0);
+         ugrid->SetUpdateGhostLevel(0);
       #endif
       ghostZones->Delete();
 

--- a/visit-plugin/mesh_reader_visit_ucd_multi.cpp
+++ b/visit-plugin/mesh_reader_visit_ucd_multi.cpp
@@ -31,6 +31,7 @@
 #include <vtkPoints.h>
 #include <vtkFloatArray.h>
 #include <vtkDoubleArray.h>
+#include <vtkInformation.h>
 #include <vtkStreamingDemandDrivenPipeline.h>
 #include <vtkIdList.h>
 #include <vtkSmartPointer.h>
@@ -404,10 +405,12 @@ namespace vlsvplugin {
 
       // Copy ghost cell information to vtkUnstructuredGrid:
       ugrid->GetCellData()->AddArray(ghostZones);
-      #ifdef NEW_VTK_API
-      vtkStreamingDemandDrivenPipeline::SetUpdateGhostLevel(ugrid->GetInformation(), 0);
+      #if VTK_API >= 71
+         ugrid->GetInformation()->Set(vtkStreamingDemandDrivenPipeline::UPDATE_NUMBER_OF_GHOST_LEVELS(), 0);
+      #elif VTK_API >= 50
+         vtkStreamingDemandDrivenPipeline::SetUpdateGhostLevel(ugrid->GetInformation(), 0);
       #else
-      ugrid->SetUpdateGhostLevel(0);
+         ugrid->SetUpdateGhostLevel(0);
       #endif
       ghostZones->Delete();
 

--- a/visit-plugin/vlsv.xml
+++ b/visit-plugin/vlsv.xml
@@ -3,15 +3,17 @@
     <CXXFLAGS>
       -std=c++0x
       -I/home/sandroos/codes/vlsv
-      -DNEW_VTK_API
+      -DVTK_API=81
     </CXXFLAGS>
     <LDFLAGS>
       -L/home/sandroos/codes/vlsv
     </LDFLAGS>
     <LIBS>
       -lvlsv
-      -lmpi
     </LIBS>
+    <DEFINES>
+      -lvlsv
+    </DEFINES>
     <FilePatterns>
       *.vlsv
     </FilePatterns>

--- a/visit-plugin/vlsv_windows.xml
+++ b/visit-plugin/vlsv_windows.xml
@@ -3,7 +3,7 @@
     <CXXFLAGS>
       -std=c++0x
       -I/home/sandroos/codes/vlsv
-      -DNEW_VTK_API
+      -DVTK_API=81
     </CXXFLAGS>
     <LDFLAGS>
       -L/home/sandroos/codes/vlsv


### PR DESCRIPTION
…tead of old/ne: at least three possible APIs now available (previously what was old-new boundary is approximately at VTK API 5.0).  2) -lmpi not needed