### PR TITLE
Readarray wrapper

### DIFF
--- a/vlsv_reader.cpp
+++ b/vlsv_reader.cpp
@@ -310,4 +310,39 @@ namespace vlsv {
       return true;
    }
 
+   /** Wrapper for readArray, converting floattype if necessary
+    * @param tagName Name of the XML tag.
+    * @param attribs List of attributes that uniquely determine the array.
+    * @param begin Index of the first read array element.
+    * @param amount How many array elements are read.
+    * @param buffer Buffer in which data is copied.
+    * @return If true, array was found and requested part was copied to buffer.*/
+   bool Reader::readArray(const std::string& tagName,const std::list<std::pair<std::string,std::string> >& attribs,
+			  const uint64_t& begin,const uint64_t& amount, double* buffer) {
+      uint64_t arraySize, vectorSize, byteSize;
+      datatype::type dataType;
+
+      if (!getArrayInfo(tagName, attribs, arraySize, vectorSize, dataType, byteSize))
+         return false;
+
+      if (dataType != datatype::FLOAT) {
+         cerr << "vlsv::Reader ERROR: Data is not float!" << endl;
+         return false;
+      }
+
+      if (byteSize == sizeof(double)) {
+         return readArray(tagName, attribs, begin, amount, (char*) buffer);
+      } else {
+         cerr << "Converting floattype for " << tagName << endl;
+         float* readBuffer = new float[amount*vectorSize];
+         if (!readArray(tagName, attribs, begin, amount, (char*) readBuffer))
+            return false;
+         for (int i = 0; i < amount*vectorSize; ++i) {
+            buffer[i] = readBuffer[i];
+         }
+         delete[] readBuffer;
+         return true;
+      }
+   }
+
 } // namespace vlsv

--- a/vlsv_reader.cpp
+++ b/vlsv_reader.cpp
@@ -319,10 +319,10 @@ namespace vlsv {
     * @return If true, array was found and requested part was copied to buffer.*/
    bool Reader::readArray(const std::string& tagName,const std::list<std::pair<std::string,std::string> >& attribs,
 			  const uint64_t& begin,const uint64_t& amount, double* buffer) {
-      uint64_t arraySize, vectorSize, byteSize;
+      uint64_t arraySize, vectorSize, dataSize;
       datatype::type dataType;
 
-      if (!getArrayInfo(tagName, attribs, arraySize, vectorSize, dataType, byteSize))
+      if (!getArrayInfo(tagName, attribs, arraySize, vectorSize, dataType, dataSize))
          return false;
 
       if (dataType != datatype::FLOAT) {
@@ -330,14 +330,13 @@ namespace vlsv {
          return false;
       }
 
-      if (byteSize == sizeof(double)) {
+      if (dataSize == sizeof(double)) {
          return readArray(tagName, attribs, begin, amount, (char*) buffer);
       } else {
-         cerr << "Converting floattype for " << tagName << endl;
          float* readBuffer = new float[amount*vectorSize];
          if (!readArray(tagName, attribs, begin, amount, (char*) readBuffer))
             return false;
-         for (int i = 0; i < amount*vectorSize; ++i) {
+         for (uint64_t i = 0; i < amount*vectorSize; ++i) {
             buffer[i] = readBuffer[i];
          }
          delete[] readBuffer;

--- a/vlsv_reader.h
+++ b/vlsv_reader.h
@@ -46,6 +46,8 @@ namespace vlsv {
       virtual bool open(const std::string& fname);
       virtual bool readArray(const std::string& tagName,const std::list<std::pair<std::string,std::string> >& attribs,
                              const uint64_t& begin,const uint64_t& amount,char* buffer);
+      bool readArray(const std::string& tagName,const std::list<std::pair<std::string,std::string> >& attribs,
+                             const uint64_t& begin,const uint64_t& amount,double* buffer);
 
       template<typename T>
       bool read(const std::string& tagName,const std::list<std::pair<std::string,std::string> >& attribs,

--- a/vlsv_reader_parallel.h
+++ b/vlsv_reader_parallel.h
@@ -45,6 +45,7 @@ namespace vlsv {
       bool open(const std::string& fname,MPI_Comm comm,const int& masterRank,MPI_Info mpiInfo=MPI_INFO_NULL);
       bool readArrayMaster(const std::string& tagName,const std::list<std::pair<std::string,std::string> >& attribs,
                            const uint64_t& begin,const uint64_t& amount,char* buffer);
+      using Reader::readArray;
       bool readArray(const std::string& tagName,const std::list<std::pair<std::string,std::string> >& attribs,
                      const uint64_t& begin,const uint64_t& amount,char* buffer);
 


### PR DESCRIPTION
Adds a wrapper for `Reader::readArray` that converts float type automatically to `double`. Currently floattype conversion is manually done in Vlasiator, leading to copypasted code and possible user errors when forgetting to convert.