### PR TITLE
Proper closing of vlsv::ParallelReader

### DIFF
--- a/vlsv_reader.cpp
+++ b/vlsv_reader.cpp
@@ -303,8 +303,9 @@ namespace vlsv {
             cerr << '\t' << it->first << " = " << it->second << endl;
          }
          cerr << "array offset string '" << node->value.c_str() << "'" << endl;
-         cerr << "start=" << start << " readBytes=" << readBytes << endl;
+         cerr << "start=" << start << " readBytes=" << readBytes << " gcount()=" << filein.gcount() << endl;
          cerr << "offset=" << arrayOpen.offset << " vectorsize=" << arrayOpen.vectorSize << " dataSize=" << arrayOpen.dataSize << endl;
+         cerr << "eof=" << filein.eof() << ", fail=" << filein.fail() << ", bad=" << filein.bad() << ", good=" << filein.good() << endl;
          return false;
       }
       return true;

--- a/vlsv_reader.h
+++ b/vlsv_reader.h
@@ -61,7 +61,7 @@ namespace vlsv {
       unsigned char endiannessFile;   /**< Endianness in VLSV file.*/
       unsigned char endiannessReader; /**< Endianness of computer which reads the data.*/
       error::type lastErrorCode;      /**< Code indicating last error that has occurred, if any.*/
-      std::fstream filein;            /**< Input file stream.*/
+      std::ifstream filein;            /**< Input file stream.*/
       std::string fileName;           /**< Name of the input file.*/
       bool fileOpen;                  /**< If true, a file is currently open.*/
       bool swapIntEndianness;         /**< If true, endianness should be swapped on read data (not implemented yet).*/

--- a/vlsv_reader_parallel.cpp
+++ b/vlsv_reader_parallel.cpp
@@ -164,7 +164,12 @@ namespace vlsv {
          parallelFileOpen = false;
       }
 
-      if (myRank == masterRank) filein.close();
+      if (myRank == masterRank)
+      { 
+         filein.close();
+         xmlReader.clear();
+         fileOpen = false;
+      }
       return true;
    }
 
@@ -434,9 +439,13 @@ namespace vlsv {
       // Only master process reads file footer and endianness. This is done using 
       // VLSVReader open() member function:
       if (myRank == masterRank) {
-         if (Reader::open(fname) == false) success = false;
+         if (Reader::open(fname) == false)
+         {
+             success = false;
+             cerr << "MASTER failed to open VLSV file, error " << Reader::getErrorString() << endl;
+         }
       }
-      if (success == false) cerr << "MASTER failed to open VLSV file" << endl;
+      if (success == false) 
 
       // Broadcast file endianness to all processes:
       MPI_Bcast(&endiannessFile,1,MPI_Type<unsigned char>(),masterRank,comm);

--- a/vlsv_reader_parallel.cpp
+++ b/vlsv_reader_parallel.cpp
@@ -164,8 +164,7 @@ namespace vlsv {
          parallelFileOpen = false;
       }
 
-      if (myRank == masterRank)
-      { 
+      if (myRank == masterRank) { 
          filein.close();
          xmlReader.clear();
          fileOpen = false;
@@ -439,13 +438,11 @@ namespace vlsv {
       // Only master process reads file footer and endianness. This is done using 
       // VLSVReader open() member function:
       if (myRank == masterRank) {
-         if (Reader::open(fname) == false)
-         {
+         if (Reader::open(fname) == false) {
              success = false;
              cerr << "MASTER failed to open VLSV file, error " << Reader::getErrorString() << endl;
          }
       }
-      if (success == false) 
 
       // Broadcast file endianness to all processes:
       MPI_Bcast(&endiannessFile,1,MPI_Type<unsigned char>(),masterRank,comm);


### PR DESCRIPTION
ParallelReader uses Reader::open for master rank, but does not use (nor replicate) Reader::close for ParallelReader::close(). Leads to failures when closing and reopening parallel files. Replicated the missing Reader::close to ParallelReader.

Also some more verbose and cleaned debug outputs, and also suggest using ifstream instead of fstream (since we are only reading).