### PR TITLE
Remove extra mpi comm free

### DIFF
--- a/Makefile.arch
+++ b/Makefile.arch
@@ -14,7 +14,7 @@
 
 # Name of MPI compiler and its flags:
 CMP = mpic++
-CXXFLAGS = -O3 -std=c++0x -Wall
+CXXFLAGS = -O3 -std=c++17 -Wall
 FLAGS =
 
 # Name of archiver:

--- a/vlsv_writer.cpp
+++ b/vlsv_writer.cpp
@@ -57,7 +57,6 @@ namespace vlsv {
    /** Destructor for Writer. Deallocates XML writer.*/
    Writer::~Writer() {
       if (fileOpen == true) close();
-      if (comm != MPI_COMM_NULL) MPI_Comm_free(&comm);
       if (bufferSize != 0) {
          delete [] outputBuffer; outputBuffer = NULL;
       }
@@ -192,6 +191,7 @@ namespace vlsv {
 
       // Wait for master process to finish:
       MPI_Barrier(comm);
+      MPI_Comm_free(&comm);
       fileOpen = false;
       return true;
    }

--- a/vlsv_writer.cpp
+++ b/vlsv_writer.cpp
@@ -191,8 +191,8 @@ namespace vlsv {
 
       // Wait for master process to finish:
       MPI_Barrier(comm);
-      MPI_Comm_free(&comm);
       fileOpen = false;
+      MPI_Comm_free(&comm);
       return true;
    }
    

--- a/vlsv_writer.cpp
+++ b/vlsv_writer.cpp
@@ -193,7 +193,6 @@ namespace vlsv {
       // Wait for master process to finish:
       MPI_Barrier(comm);
       fileOpen = false;
-      MPI_Comm_free(&comm);
       return true;
    }
    


### PR DESCRIPTION
This was causing a crash when using TAU. Possibly related to other mysterious things we encountered in past years.