### PR TITLE
Plugin expansion

### DIFF
--- a/visit-plugin/VlsvCommonPluginInfo.C
+++ b/visit-plugin/VlsvCommonPluginInfo.C
@@ -40,6 +40,7 @@
 #include <avtVlsvFileFormat.h>
 #include <avtSTMDFileFormatInterface.h>
 #include <avtGenericDatabase.h>
+#include <avtVlsvDatabase.h>
 
 // ****************************************************************************
 //  Method:  VlsvCommonPluginInfo::GetDatabaseType
@@ -51,8 +52,7 @@
 //  Creation:    omitted
 //
 // ****************************************************************************
-DatabaseType
-VlsvCommonPluginInfo::GetDatabaseType()
+DatabaseType VlsvCommonPluginInfo::GetDatabaseType()
 {
     return DB_TYPE_STMD;
 }
@@ -81,5 +81,5 @@ avtDatabase* VlsvCommonPluginInfo::SetupDatabase(const char *const *list,int nLi
    }
    avtSTMDFileFormatInterface *inter
      = new avtSTMDFileFormatInterface(ffl, nList);
-   return new avtGenericDatabase(inter);
+   return new avtVlsvDatabase(inter);
 }

--- a/visit-plugin/VlsvCommonPluginInfo.C
+++ b/visit-plugin/VlsvCommonPluginInfo.C
@@ -81,5 +81,5 @@ avtDatabase* VlsvCommonPluginInfo::SetupDatabase(const char *const *list,int nLi
    }
    avtSTMDFileFormatInterface *inter
      = new avtSTMDFileFormatInterface(ffl, nList);
-   return new avtVlsvDatabase(inter);
+   return new avtGenericDatabase(inter);
 }

--- a/visit-plugin/VlsvCommonPluginInfo.C
+++ b/visit-plugin/VlsvCommonPluginInfo.C
@@ -81,5 +81,5 @@ avtDatabase* VlsvCommonPluginInfo::SetupDatabase(const char *const *list,int nLi
    }
    avtSTMDFileFormatInterface *inter
      = new avtSTMDFileFormatInterface(ffl, nList);
-   return new avtGenericDatabase(inter);
+   return new avtVlsvDatabase(inter);
 }

--- a/visit-plugin/avtVlsvDatabase.cpp
+++ b/visit-plugin/avtVlsvDatabase.cpp
@@ -1,0 +1,134 @@
+#include <avtVlsvDatabase.h>
+
+#include <algorithm>
+#include <float.h>
+
+#ifdef PARALLEL
+#include <mpi.h>
+#endif
+
+#include <vtkCell.h>
+#include <vtkCellData.h>
+#include <vtkCSGGrid.h>
+#include <vtkDataSet.h>
+#include <vtkDataSetWriter.h>
+#include <vtkDoubleArray.h>
+#include <vtkEnumThreshold.h>
+#include <vtkFloatArray.h>
+#include <vtkIdList.h>
+#include <vtkInformation.h>
+#include <vtkIntArray.h>
+#include <vtkMath.h>
+#include <vtkPointData.h>
+#include <vtkPointSet.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkPolyDataRelevantPointsFilter.h>
+#include <vtkRectilinearGrid.h>
+#include <vtkStructuredGrid.h>
+#include <vtkTrivialProducer.h>
+#include <vtkUnsignedCharArray.h>
+#include <vtkUnsignedIntArray.h>
+#include <vtkUnstructuredGrid.h>
+#include <vtkUnstructuredGridBoundaryFilter.h>
+#include <vtkUnstructuredGridFacelistFilter.h>
+#include <vtkVisItUtility.h>
+
+#include <visitstream.h>
+
+#include <avtCallback.h>
+#include <avtDatabaseMetaData.h>
+#include <avtDatasetCollection.h>
+#include <avtDatasetVerifier.h>
+#include <avtDebugDumpOptions.h>
+#include <avtDomainBoundaries.h>
+#include <avtDomainNesting.h>
+#include <avtFileFormatInterface.h>
+#include <avtGhostNodeGenerator.h>
+#include <avtMemory.h>
+#include <avtMixedVariable.h>
+#include <avtParallel.h>
+#include <avtSILGenerator.h>
+#include <avtSILRestrictionTraverser.h>
+#include <avtSourceFromDatabase.h>
+#include <avtStreamingGhostGenerator.h>
+#include <avtStructuredDomainBoundaries.h>
+#include <avtLocalStructuredDomainBoundaries.h>
+#include <avtStructuredDomainNesting.h>
+#include <avtTransformManager.h>
+#include <avtTypes.h>
+#include <avtUnstructuredPointBoundaries.h>
+#include <PickAttributes.h>
+#include <PickVarInfo.h>
+#include <QueryOverTimeAttributes.h>
+
+#include <DebugStream.h>
+#include <BadDomainException.h>
+#include <ImproperUseException.h>
+#include <InvalidDBTypeException.h>
+#include <InvalidVariableException.h>
+#include <NoInputException.h>
+#include <TimingsManager.h>
+
+
+
+using     std::string;
+using     std::vector;
+
+avtVlsvDatabase::avtVlsvDatabase(avtFileFormatInterface *inter)
+: avtGenericDatabase(inter)
+{
+}
+
+avtVlsvDatabase::~avtVlsvDatabase()
+{
+}
+
+// ****************************************************************************
+//  Method: avtGenericDatabase::SetDatabaseMetaData
+//
+//  Purpose:
+//      Sets the database meta-data using the file format interface.
+//
+//  Arguments:
+//      md        : The meta-data to set.
+//      timeState : The time state that we're interested in.
+//
+//  Programmer: Hank Childs
+//  Creation:   March 2, 2001
+//
+//  Modifications:
+//    Brad Whitlock, Wed May 14 09:15:18 PDT 2003
+//    I added the optional timeState argument.
+//
+//    Hank Childs, Tue Feb 15 07:21:10 PST 2005
+//    Replace forbidden characters of expression language.
+//
+//    Mark C. Miller, Tue May 17 18:48:38 PDT 2005
+//    Added bool arg, forceReadAllCyclesTimes
+//
+//    Jeremy Meredith, Fri Sep  2 15:03:06 PDT 2005
+//    Removed most of the special character replacements, as the expression
+//    language scanner is now accepting most of them inside <>'s.  Replaced
+//    the unacceptable [] <> () with the acceptable {}'s since it seems
+//    more natural than the former _ character used to replace them.
+//
+//    Hank Childs, Sun Mar 16 07:10:49 PDT 2008
+//    Change substitutions for (, }, [, ], <, and > to use an underscore,
+//    instead of { & }, since that was screwing up expressions.
+//
+//    Dave Pugmire, Thu Mar  4 10:27:17 EST 2010
+//    Ensure that naming collisions don't occur. Previously ()[]<> all mapped
+//    to '_'.
+//
+//    Markku Alho: Force reading time & cycle from vlsv files
+// ****************************************************************************
+
+void avtVlsvDatabase::SetDatabaseMetaData(avtDatabaseMetaData *md, int timeState, bool forceReadAllCyclesTimes)
+{
+    debug2 << "VLSV\t SetDataBaseMetaData called\n";
+    int t0 = visitTimer->StartTimer();
+    Interface->SetDatabaseMetaData(md, timeState, true);
+    md->ReplaceForbiddenCharacters();
+    visitTimer->StopTimer(t0, "Getting database meta data");
+}

--- a/visit-plugin/avtVlsvDatabase.cpp
+++ b/visit-plugin/avtVlsvDatabase.cpp
@@ -128,7 +128,8 @@ void avtVlsvDatabase::SetDatabaseMetaData(avtDatabaseMetaData *md, int timeState
 {
     debug2 << "VLSV\t SetDataBaseMetaData called\n";
     int t0 = visitTimer->StartTimer();
-    Interface->SetDatabaseMetaData(md, timeState, true);
+    // Interface->SetDatabaseMetaData(md, timeState, true);    // This will force the read even when loading the database. Performance impact is significant, not worth it.
+    Interface->SetDatabaseMetaData(md, timeState, forceReadAllCyclesTimes);
     md->ReplaceForbiddenCharacters();
     visitTimer->StopTimer(t0, "Getting database meta data");
 }

--- a/visit-plugin/avtVlsvDatabase.h
+++ b/visit-plugin/avtVlsvDatabase.h
@@ -1,0 +1,21 @@
+#ifndef AVT_VLSV_DATABASE_H
+#define AVT_VLSV_DATABASE_H
+
+#include <avtDatasetDatabase.h>
+#include <avtGenericDatabase.h>
+#include <avtMaterial.h>
+#include <avtSpecies.h>
+#include <avtVariableCache.h>
+#include <avtTransformManager.h>
+#include <avtFileFormatInterface.h>
+
+class DATABASE_API avtVlsvDatabase : public avtGenericDatabase
+{
+    public:
+        avtVlsvDatabase(avtFileFormatInterface *);
+        virtual ~avtVlsvDatabase();
+    protected:
+        virtual void SetDatabaseMetaData(avtDatabaseMetaData *md, int timeState, bool forceReadAllCyclesTimes = true);
+};
+
+#endif

--- a/visit-plugin/avtVlsvFileFormat.C
+++ b/visit-plugin/avtVlsvFileFormat.C
@@ -41,6 +41,7 @@
 // ************************************************************************* //
 
 #include <avtVlsvFileFormat.h>
+#include <avtIntervalTree.h>
 
 #include <string>
 
@@ -662,6 +663,39 @@ vtkDataArray* avtVlsvFileFormat::GetVar(int domain,const char* varname) {
    vtkDataArray* rv = ReadVariable(domain,varname);
    if (rv == NULL) EXCEPTION1(InvalidVariableException, varname);
    return rv;
+}
+
+
+
+// ****************************************************************************
+//  Method: avtSTMDFileFormat::GetAuxiliaryData
+//
+//  Purpose:
+//      Gets the auxiliary data specified.
+//
+//  Arguments:
+//      <unnamed>  The variable of interest.
+//      <unnamed>  The domain of interest.
+//      <unnamed>  The type of auxiliary data.
+//      <unnamed>  The arguments for that type.
+//
+//  Returns:    The auxiliary data.  Throws an exception if this is not a
+//              supported data type.
+//
+//  Programmer: Hank Childs
+//  Creation:   February 23, 2001
+//
+// ****************************************************************************
+
+void *
+avtVlsvFileFormat::GetAuxiliaryData(const char *var, int domain, const char *type,
+                                     void *args, DestructorFunction &)
+{
+    //
+    // This is defined only so the simple file formats that have no auxiliary
+    // data don't have to define this.
+    //
+    return NULL;
 }
 
 

--- a/visit-plugin/avtVlsvFileFormat.C
+++ b/visit-plugin/avtVlsvFileFormat.C
@@ -266,17 +266,23 @@ void avtVlsvFileFormat::PopulateDatabaseMetaData(avtDatabaseMetaData* md) {
    debug2 << "VLSV\t file'" << inputFile << "' timestep: " << timestep << endl;
    debug3 << "VLSV\t object " << objectNumber << " / " << objectCounter << endl;
 
+   string dummy;
    // ActivateTimeStep should get called prior to this function.
    // Check that a VLSV file is open:
    if (vlsvReader == NULL) {
       debug2 << "VLSV\t VLSVReader in NULL, calling ActivateTimestep()." << endl;
       ActivateTimestep();
    }
-   string dummy;
-   if (vlsvReader->getFileName(dummy) == false) {
-      debug2 << "VLSV\t ERROR: Input file has not been opened." << endl;
-      return;
-   }
+   // debug2 << "VLSV\t checking for VLSVReader filename mismatch." << endl;
+   // vlsvReader->getFileName(dummy);
+   // if (dummy.compare(inputFile) != 0) {
+   //    debug2 << "VLSV\t VLSVReader filename mismatch, calling ActivateTimestep()." << endl;
+   //    ActivateTimestep();
+   // }
+   // if (vlsvReader->getFileName(dummy) == false) {
+   //    debug2 << "VLSV\t ERROR: Input file has not been opened." << endl;
+   //    return;
+   // }
    
    // Read simulation time and time step.
    // Add them to metadata if they were found:
@@ -688,8 +694,10 @@ int avtVlsvFileFormat::GetCycle(void) {
 
    // Check that VLSVReader is not NULL:
    if (vlsvReader == NULL) {
-      debug1 << "VLSV\t ERROR: VLSVReader is NULL." << endl;
-      return INVALID_CYCLE;
+      // debug1 << "VLSV\t ERROR: VLSVReader is NULL." << endl;
+      // return INVALID_CYCLE;
+      debug2 << "VLSV\t VLSVReader in NULL, calling ActivateTimestep()." << endl;
+      ActivateTimestep();
    }
    
    // Read simulation timestep:
@@ -711,8 +719,10 @@ double avtVlsvFileFormat::GetTime(void) {
 
    // Check that VLSVReader is not NULL:
    if (vlsvReader == NULL) {
-      debug1 << "VLSV\t ERROR: VLSVReader is NULL." << endl;
-      return INVALID_TIME;
+      // debug1 << "VLSV\t ERROR: VLSVReader is NULL." << endl;
+      // return INVALID_TIME;
+      debug2 << "VLSV\t VLSVReader in NULL, calling ActivateTimestep()." << endl;
+      ActivateTimestep();
    }
    
    // Read simulation time:

--- a/visit-plugin/avtVlsvFileFormat.h
+++ b/visit-plugin/avtVlsvFileFormat.h
@@ -72,8 +72,8 @@ class avtVlsvFileFormat: public avtSTMDFileFormat {
     // This is used to return unconvention data -- ranging from material
     // information to information about block connectivity.
     //
-    // virtual void      *GetAuxiliaryData(const char *var, const char *type,
-    //                                  void *args, DestructorFunction &);
+    virtual void      *GetAuxiliaryData(const char *var, int someInt, const char *type,
+                                     void *args, DestructorFunction &);
     //
 
     //

--- a/visit-plugin/vlsv.xml
+++ b/visit-plugin/vlsv.xml
@@ -2,11 +2,11 @@
   <Plugin name="Vlsv" type="database" label="VLSV parallel file format" version="1.0" enabled="true" mdspecificcode="false" engspecificcode="false" onlyengine="false" noengine="false" dbtype="STMD" haswriter="false" hasoptions="false" filePatternsStrict="false" opensWholeDirectory="false">
     <CXXFLAGS>
       -std=c++0x
-      -I/home/sandroos/codes/vlsv
+      -I/home/mjalho/Vlasiator/lib/vlsv
       -DVTK_API=81
     </CXXFLAGS>
     <LDFLAGS>
-      -L/home/sandroos/codes/vlsv
+      -L/home/mjalho/Vlasiator/lib/vlsv
     </LDFLAGS>
     <LIBS>
       -lvlsv
@@ -19,6 +19,7 @@
     </FilePatterns>
     <Files components="M">
       duplicate_node_elimination.cpp
+      avtVlsvDatabase.cpp
       avtVlsvFileFormat.C
       mesh_metadata.cpp
       mesh_reader.cpp
@@ -37,6 +38,7 @@
     </Files>
     <Files components="E">
       duplicate_node_elimination.cpp
+      avtVlsvDatabase.cpp
       avtVlsvFileFormat.C
       mesh_metadata.cpp
       mesh_reader.cpp

--- a/vlsv_reader_parallel.h
+++ b/vlsv_reader_parallel.h
@@ -81,15 +81,21 @@ namespace vlsv {
                              const uint64_t& begin,const uint64_t& amount,T*& outBuffer,bool allocateMemory) {
       // Get array info to all processes:
       if (ParallelReader::getArrayInfo(tagName,attribs) == false) {
+         std::cerr << "Failure in ParallelReader::getArrayInfo\n";
          return false;
       }
 
       // Check that requested read is inside the array:
-      if (begin > arrayOpen.arraySize || (begin+amount) > arrayOpen.arraySize) return false;
+      if (begin > arrayOpen.arraySize || (begin+amount) > arrayOpen.arraySize){
+         std::cerr << "Failure in ParallelReader::read, trying to read out of bounds.\n";
+         std::cerr << "begin: " << begin << ", amount " << amount <<", arrayOpen.arraySize " << arrayOpen.arraySize << "\n";
+         return false;
+      } 
 
       char* buffer = new char[amount*arrayOpen.vectorSize*arrayOpen.dataSize];
       if (ParallelReader::readArray(tagName,attribs,begin,amount,buffer) == false) {
          delete [] buffer; buffer = NULL;
+         std::cerr << "Failure in ParallelReader::readArray\n";
          return false;
       }
 


### PR DESCRIPTION
Expanding beyond the barebones vslv reader interface. So far, here is a wrapper for a vlsv database, that can extract good time information as long as "Try harder to obtain correct times" is checked.

Todos:
* bounding boxes extraction for write-rank domains to use for building interval trees
* ... find what useful settings can be forced for vlsv, like "Treat all databases as time-varying"