### PR TITLE
MuXML to return false if it is reading after EOF

### DIFF
--- a/muxml.cpp
+++ b/muxml.cpp
@@ -139,6 +139,7 @@ bool MuXML::read(std::istream& in,XMLNode* parent,const int& level,const char& c
    
    int index = 0;
    bool success = true;
+   bool xml_found = false;
    char c = currentChar;
    char buffer[1024];
    do {
@@ -147,6 +148,7 @@ bool MuXML::read(std::istream& in,XMLNode* parent,const int& level,const char& c
       
       // Start to read tag name and its attributes:
       if (c == '<') {
+	 xml_found = true;
 	 in >> c;
 	 while ((c == ' ' || c == '\t' || c == '\n') && in.good() == true) in >> c;
 	 
@@ -227,7 +229,7 @@ bool MuXML::read(std::istream& in,XMLNode* parent,const int& level,const char& c
       
       if (in.good() == false && in.eof() == false) return false;
       if (in.eof() == true) {
-         return true;
+		return xml_found;
       }
    } while (success == true);
    return true;

--- a/muxml.cpp
+++ b/muxml.cpp
@@ -145,7 +145,7 @@ bool MuXML::read(std::istream& in,XMLNode* parent,const int& level,const char& c
    do {
       // Skip empty chars:
       while ((c == ' ' || c == '\t' || c == '\n') && in.good() == true) in >> c;
-      
+	  if(in.good() == false){ return false;}
       // Start to read tag name and its attributes:
       if (c == '<') {
 	 xml_found = true;
@@ -229,7 +229,7 @@ bool MuXML::read(std::istream& in,XMLNode* parent,const int& level,const char& c
       
       if (in.good() == false && in.eof() == false) return false;
       if (in.eof() == true) {
-		return xml_found;
+        return xml_found;
       }
    } while (success == true);
    return true;

--- a/muxml.cpp
+++ b/muxml.cpp
@@ -145,7 +145,7 @@ bool MuXML::read(std::istream& in,XMLNode* parent,const int& level,const char& c
    do {
       // Skip empty chars:
       while ((c == ' ' || c == '\t' || c == '\n') && in.good() == true) in >> c;
-	  if(in.good() == false){ return false;}
+      if(in.good() == false){ return false;}
       // Start to read tag name and its attributes:
       if (c == '<') {
 	 xml_found = true;

--- a/vlsv_reader.cpp
+++ b/vlsv_reader.cpp
@@ -218,6 +218,13 @@ namespace vlsv {
       }
       footerOffset = convUInt64(buffer,swapIntEndianness);
 
+      filein.seekg(0, filein.end);
+      uint64_t filein_length = filein.tellg();
+      if (filein_length < footerOffset){
+         std::cerr << "Footer offset beyond EOF. VLSV file truncated?\n";
+         return false;
+      }
+
       // Read footer XML tree:
       filein.seekg(footerOffset);
       if (filein.tellg() != footerOffset) {


### PR DESCRIPTION
Reading the XML footer reports success even if it is reading beyond EOF. Let's maybe not do that and let VisIt plugin and restart reads fail gracefully..