### PR TITLE
Remove unused amount from vlsv_writer.cpp

### DIFF
--- a/vlsv_writer.cpp
+++ b/vlsv_writer.cpp
@@ -525,7 +525,6 @@ namespace vlsv {
 
       // Copy pointers etc. to MPI struct:
       uint64_t i=0;
-      uint64_t amount = 0;
       for (list<Multi_IO_Unit>::iterator it=start; it!=stop; ++it) {
          blockLengths[i]  = (*it).amount;
          displacements[i] = (*it).array - multiwriteOffsetPointer;
@@ -533,7 +532,6 @@ namespace vlsv {
 
          int datatypeBytesize;
          MPI_Type_size(it->mpiType,&datatypeBytesize);
-         amount += (*it).amount * datatypeBytesize;
          
          ++i;
       }


### PR DESCRIPTION
GCC 16.1.1 gives:
```
vlsv_writer.cpp:528:16: warning: muuttuja ”amount” asetettu mutta käyttämätön [-Wunused-but-set-variable=]
  528 |       uint64_t amount = 0;
      |                ^~~~~~
```