### PR TITLE
Remove unused outer t_start from vlsv_writer.cpp

### DIFF
--- a/vlsv_writer.cpp
+++ b/vlsv_writer.cpp
@@ -561,7 +561,6 @@ namespace vlsv {
          // empty the buffer before, might not be needed but lets be safe
          emptyBuffer(comm);         
          // Write data to output file with a single collective call:
-         const double t_start = MPI_Wtime();
          if (N_multiwriteUnits > 0) {
             // Write data to output file with a single collective call:
             const double t_start = MPI_Wtime();


### PR DESCRIPTION
GCC 16.1.1 gives:
```
vlsv_writer.cpp:562:23: warning: unused variable ”t_start” [-Wunused-variable]
  562 |          const double t_start = MPI_Wtime();
      |                       ^~~~~~~
```