### PR TITLE
Remove comparison warning from vlsv_reader_parallel.cpp

### DIFF
--- a/vlsv_reader_parallel.cpp
+++ b/vlsv_reader_parallel.cpp
@@ -524,7 +524,7 @@ namespace vlsv {
          if(readSize>0) {
             int bytesReceived;
             MPI_Get_count(&status,MPI_BYTE,&bytesReceived);
-            if (bytesReceived != readSize) {
+            if (bytesReceived != (int)readSize) {
                stringstream ss;
                ss << "ERROR in vlsv::ParallelReader! I only got " << bytesReceived << "/" << readSize;
                ss << " bytes in " << __FILE__ << ":" << __LINE__ << endl;


### PR DESCRIPTION
GCC 16.1.1 gives:
```
vlsv_reader_parallel.cpp:526:31: warning: etumerkiltään eroavien kokonaislukulausekkeiden vertailu: ”int” ja ”uint64_t” {aka ”long unsigned int”} [-Wsign-compare]
  526 |             if (bytesReceived != readSize) {
      |                 ~~~~~~~~~~~~~~^~~~~~~~~~~
```