### PR TITLE
Remove hidden open warning from vlsv_reader_parallel.h

### DIFF
--- a/vlsv_reader_parallel.h
+++ b/vlsv_reader_parallel.h
@@ -42,6 +42,7 @@ namespace vlsv {
       uint64_t getBytesRead();
       double getReadTime() const;
       bool getUniqueAttributeValues(const std::string& tagName,const std::string& attribName,std::set<std::string>& output) const;
+      using Reader::open;
       bool open(const std::string& fname,MPI_Comm comm,const int& masterRank,MPI_Info mpiInfo=MPI_INFO_NULL);
       bool readArrayMaster(const std::string& tagName,const std::list<std::pair<std::string,std::string> >& attribs,
                            const uint64_t& begin,const uint64_t& amount,char* buffer);


### PR DESCRIPTION
GCC 16.1.1 gives:
```
In file included from vlsv_reader_parallel.h:24,
                 from vlsv_reader_parallel.cpp:25:
vlsv_reader.h:46:20: warning: ”virtual bool vlsv::Reader::open(const std::string&)” was hidden [-Woverloaded-virtual=]
   46 |       virtual bool open(const std::string& fname);
      |                    ^~~~
vlsv_reader_parallel.h:45:12: note:   by ”bool vlsv::ParallelReader::open(const std::string&, MPI_Comm, const int&, MPI_Info)”
   45 |       bool open(const std::string& fname,MPI_Comm comm,const int& masterRank,MPI_Info mpiInfo=MPI_INFO_NULL);
      |            ^~~~
```