### PR TITLE
Remove comparison warning from vlsv_reader.cpp

### DIFF
--- a/vlsv_reader.cpp
+++ b/vlsv_reader.cpp
@@ -227,7 +227,7 @@ namespace vlsv {
 
       // Read footer XML tree:
       filein.seekg(footerOffset);
-      if (filein.tellg() != footerOffset) {
+      if (filein.tellg() != (int)footerOffset) {
          lastErrorCode = error::READ_NO_FOOTER;
          success = false;
       }


### PR DESCRIPTION
GCC 16.1.1 gives:
```
vlsv_reader.cpp:230:26: warning: etumerkiltään eroavien kokonaislukulausekkeiden vertailu: ”std::streamoff” {aka ”long int”} ja ”uint64_t” {aka ”long unsigned int”} [-Wsign-compare]
  230 |       if (filein.tellg() != footerOffset) {
      |           ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
```